### PR TITLE
fix(interface): Improve `in_app` detection

### DIFF
--- a/src/golare.erl
+++ b/src/golare.erl
@@ -36,7 +36,7 @@ event(Attrs, Interfaces) ->
         {optional, level}
     ],
     Event = lists:foldl(fun(Attr, Acc) -> attr(Attr, Attrs, Acc) end, #{}, Attributes),
-    mapz:deep_merge([Event|Interfaces]).
+    mapz:deep_merge([Event | Interfaces]).
 
 attr({_, Key}, Attrs, Acc) when is_map_key(Key, Attrs) ->
     Value = maps:get(Key, Attrs),

--- a/src/golare_interface.erl
+++ b/src/golare_interface.erl
@@ -174,16 +174,24 @@ exception_stacktrace_frame({Module, Function, Args, Meta}) ->
         end,
     File = proplists:get_value(file, Meta),
     #{
-        in_app =>
-            case File of
-                "/" ++ _ -> true;
-                _ -> false
-            end,
+        in_app => exception_stacktrace_frame_in_app(File),
         function => iolist_to_binary(io_lib:format("~p/~p", [Function, Arity])),
         filename => Module,
         abs_path => iolist_to_binary(File),
         lineno => proplists:get_value(line, Meta)
     }.
+
+exception_stacktrace_frame_in_app("/" ++ _ = File) ->
+    % Rebar3 keeps dependency source trees under `_build`, so absolute paths
+    % that do not contain `_build` are treated as application code.
+    case string:find(File, ~"/_build/") of
+        nomatch -> true;
+        _Match -> false
+    end;
+exception_stacktrace_frame_in_app(_File) ->
+    % OTP module frames typically don't include absolute file paths and should
+    % not be treated as application code.
+    false.
 
 request_cowboy_url({Scope, Req0}) ->
     URL = uri_string:recompose(#{

--- a/test/golare_event_SUITE.erl
+++ b/test/golare_event_SUITE.erl
@@ -17,6 +17,7 @@ all() ->
         timestamp_invalid,
         exception,
         exception_handled,
+        exception_in_app,
         message,
         request,
         thread,
@@ -85,6 +86,40 @@ exception_handled(_Config) ->
                     value := ~"undef",
                     mechanism := #{type := auto, handled := true},
                     stacktrace := #{frames := []}
+                }
+            ]
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+exception_in_app(_Config) ->
+    Result = golare:event(#{}, [
+        golare_interface:exception(error, test_error, [
+            {module, function, [a, b, c], [
+                {file, "/project/src/full_build/module.erl"}, {line, 123}
+            ]},
+            {library, utility, 2, [
+                {file, "/project/_build/default/lib/library/src/library.erl"}, {line, 456}
+            ]},
+            {lists, all, 2, [
+                {file, "lists.erl"}, {line, 2313}
+            ]}
+        ])
+    ]),
+    ?assertMatch(
+        #{
+            exception := [
+                #{
+                    type := error,
+                    value := ~"test_error",
+                    stacktrace := #{
+                        frames := [
+                            #{filename := lists, in_app := false},
+                            #{filename := library, in_app := false},
+                            #{filename := module, in_app := true}
+                        ]
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Extracts inline `in_app` logic into a dedicated
`exception_stacktrace_frame_in_app/1` function and excludes `_build` paths (dependencies) from being marked as in-app frames.