### PR TITLE
fix(logger): build exception stacktrace from log metadata

### DIFF
--- a/src/golare_interface.erl
+++ b/src/golare_interface.erl
@@ -173,13 +173,22 @@ exception_stacktrace_frame({Module, Function, Args, Meta}) ->
             A when is_list(A) -> length(A)
         end,
     File = proplists:get_value(file, Meta),
-    #{
+    Frame0 = #{
         in_app => exception_stacktrace_frame_in_app(File),
         function => iolist_to_binary(io_lib:format("~p/~p", [Function, Arity])),
-        filename => Module,
-        abs_path => iolist_to_binary(File),
-        lineno => proplists:get_value(line, Meta)
-    }.
+        filename => Module
+    },
+    % Raw process stacktraces (e.g. BIF frames like `{erlang, apply, 2, []}`)
+    % may carry no file or line, so only add those keys when present.
+    Frame1 =
+        case File of
+            undefined -> Frame0;
+            _ -> Frame0#{abs_path => iolist_to_binary(File)}
+        end,
+    case proplists:get_value(line, Meta) of
+        undefined -> Frame1;
+        Line -> Frame1#{lineno => Line}
+    end.
 
 exception_stacktrace_frame_in_app("/" ++ _ = File) ->
     % Rebar3 keeps dependency source trees under `_build`, so absolute paths

--- a/src/golare_logger_h.erl
+++ b/src/golare_logger_h.erl
@@ -63,7 +63,8 @@ log(LogEvent, _Config) ->
             timestamp => event_timestamp(LogEvent)
         },
         Event1 = logger_name(Event0, LogEvent),
-        Event = describe(Event1, LogEvent),
+        Event2 = describe(Event1, LogEvent),
+        Event = maybe_exception(Event2, LogEvent),
         {ok, _EventId} = golare:capture_event(Event)
     catch
         exit:{noproc, _} ->
@@ -311,6 +312,53 @@ describe_log(E0, Message, Report, Meta) when is_map(Report) ->
 
 maybe_mfa(E0, _Message, _Meta) ->
     E0.
+
+%% Attach a Sentry Exception interface when the log event carries a stacktrace
+%% in its metadata, e.g. `logger:warning(Report, #{stacktrace => Stacktrace})`.
+%% Without this the stacktrace is silently dropped and Sentry shows no frames.
+%% Crash reports handled by describe/2 build their own exception/threads, so
+%% leave those untouched.
+maybe_exception(#{exception := _} = Event, _LogEvent) ->
+    Event;
+maybe_exception(#{threads := _} = Event, _LogEvent) ->
+    Event;
+maybe_exception(Event, #{meta := #{stacktrace := [_ | _] = Stacktrace}} = LogEvent) ->
+    {Class, Reason} = exception_class_reason(LogEvent),
+    maps:merge(Event, golare_interface:exception(Class, Reason, Stacktrace, #{handled => true}));
+maybe_exception(Event, _LogEvent) ->
+    Event.
+
+exception_class_reason(#{meta := #{class := Class}} = LogEvent) when is_atom(Class) ->
+    {Class, exception_reason(LogEvent)};
+exception_class_reason(LogEvent) ->
+    {error, exception_reason(LogEvent)}.
+
+exception_reason(#{msg := {report, Report}}) when is_map(Report) ->
+    map_reason(Report, [exception, reason, error, msg, message]);
+exception_reason(#{msg := {report, Report}}) when is_list(Report) ->
+    list_reason(Report, [exception, reason, error, msg, message]);
+exception_reason(#{msg := {string, Raw}}) ->
+    Raw;
+exception_reason(#{msg := {Format, Args}}) when is_list(Args) ->
+    format(Format, Args);
+exception_reason(#{msg := Msg}) ->
+    Msg.
+
+map_reason(Report, []) ->
+    Report;
+map_reason(Report, [Key | Keys]) ->
+    case Report of
+        #{Key := Value} -> Value;
+        _ -> map_reason(Report, Keys)
+    end.
+
+list_reason(Report, []) ->
+    Report;
+list_reason(Report, [Key | Keys]) ->
+    case lists:keyfind(Key, 1, Report) of
+        {Key, Value} -> Value;
+        false -> list_reason(Report, Keys)
+    end.
 
 frame({M, F, A, Opts}) ->
     case A of

--- a/test/golare_sentry_SUITE.erl
+++ b/test/golare_sentry_SUITE.erl
@@ -68,6 +68,7 @@ groups() ->
             format_log,
             format_log_mfa,
             report_map,
+            report_meta_stacktrace,
             supervisor_crash,
             proc_lib_crash
         ]}
@@ -395,6 +396,53 @@ report_map(_Config) ->
         },
         Item
     ),
+    ok.
+
+report_meta_stacktrace(_Config) ->
+    %% Mirrors rest_prelude:do_error_response/3 in kivra_core, which logs
+    %% `?warning(Report#{exception => Ex}, #{stacktrace => Stacktrace})` where
+    %% Stacktrace is a raw process stacktrace. The last frame has no file/line
+    %% (like a BIF frame) to exercise fileless-frame handling.
+    Stacktrace = [
+        {rest_util_notification_info_content, content, 2, [
+            {file, "/buildroot/src/rest/util/rest_util_notification_info_content.erl"}, {line, 42}
+        ]},
+        {rest_prelude, do_error_response, 3, [
+            {file, "/buildroot/src/rest/rest_prelude.erl"}, {line, 487}
+        ]},
+        {erlang, apply, 2, []}
+    ],
+    Report = #{
+        reason => {"Unknown failure reason", rest_util_notification_info_content},
+        resource => rest_util_notification_info_content,
+        exception => {badmatch, false}
+    },
+    Meta = #{
+        time => 0,
+        mfa => {rest_prelude, do_error_response, 3},
+        stacktrace => Stacktrace
+    },
+    LogItem = #{level => warning, meta => Meta, msg => {report, Report}},
+    {ok, EventId} = golare_logger_h:log(LogItem, #{}),
+    {_, Item} = wait_for(EventId),
+    ct:pal(default, "Captured:~n~p", [Item]),
+    ?assertMatch(
+        #{
+            <<"level">> := <<"warning">>,
+            <<"logger">> := <<"rest_prelude:do_error_response/3">>,
+            <<"logentry">> := #{<<"formatted">> := _},
+            <<"exception">> := [
+                #{
+                    <<"type">> := <<"error">>,
+                    <<"value">> := <<"{badmatch,false}">>,
+                    <<"stacktrace">> := #{<<"frames">> := _}
+                }
+            ]
+        },
+        Item
+    ),
+    #{<<"exception">> := [#{<<"stacktrace">> := #{<<"frames">> := Frames}}]} = Item,
+    ?assertEqual(3, length(Frames)),
     ok.
 
 wait_for(EventId) ->


### PR DESCRIPTION
## Problem

The logger handler only produced Sentry stacktrace frames for **structured OTP crash reports** (`proc_lib`/`gen_server`/`supervisor`). A plain `logger:warning(Report, #{stacktrace => Stacktrace})` — as emitted by application error handlers that catch an exception and log it with the lifted stacktrace in metadata — had its stacktrace **silently dropped**. The resulting Sentry event carried only a message + extras and no frames.

This is the path used by `kivra_core`'s `rest_prelude:do_error_response/3`, which logs:

```erlang
?warning(Report#{exception => Ex}, #{stacktrace => Stacktrace})
```

where `Stacktrace` is the raw process stacktrace lifted from a caught exception (`stdlib2` `{lifted_exn, Exn, ST}`).

## Fix

Wire the existing `golare_interface:exception/4` builder into the handler via a new `maybe_exception/2` step in `log/2`:

- When a log event carries a non-empty `stacktrace` in its metadata, attach a Sentry Exception interface with the frames.
- Exception class is taken from `meta.class` when present, otherwise `error`.
- Exception value is extracted from the report's `exception` / `reason` / `error` / `msg` / `message` field.
- Crash reports handled by `describe/2` already build their own `exception`/`threads`, so those are left untouched (guarded).

Also harden `golare_interface:exception_stacktrace_frame/1`: raw process stacktraces can contain frames with **no file or line** (e.g. BIF frames like `{erlang, apply, 2, []}`), which previously crashed on `iolist_to_binary(undefined)` — turning a real error into a useless "golare sdk crash" event. `abs_path`/`lineno` are now emitted only when present.

## Verification

- `golare_event_SUITE` + `golare_sentry_SUITE` pass (24/24), including a new `report_meta_stacktrace` case that replicates the `kivra_core` log shape end-to-end through the mock Sentry server and asserts `exception[].stacktrace.frames`. It includes a fileless frame to cover the hardening.
- Ran two real production log samples through the builder. Both produce correct frames: application frames resolve to `in_app=true` (highlighted) and dependency/OTP frames (paths under `/_build/`, or bare `lists.erl`) to `in_app=false`, ordered oldest-first per Sentry convention.

## Note on grouping

Events that previously grouped by message will regroup by the in-app stacktrace frames once an `exception` interface is present, so distinct bug sites become distinct issues.