### PR TITLE
feat(logger): attach exception stacktrace from log events

### DIFF
--- a/src/golare_logger_h.erl
+++ b/src/golare_logger_h.erl
@@ -63,7 +63,8 @@ log(LogEvent, _Config) ->
             timestamp => event_timestamp(LogEvent)
         },
         Event1 = logger_name(Event0, LogEvent),
-        Event = describe(Event1, LogEvent),
+        Event2 = describe(Event1, LogEvent),
+        Event = maybe_exception(Event2, LogEvent),
         {ok, _EventId} = golare:capture_event(Event)
     catch
         exit:{noproc, _} ->
@@ -309,6 +310,88 @@ describe_log(E0, Message, Report, Meta) when is_map(Report) ->
         extra => #{K => print(V) || K := V <- Report, is_atom(K)}
     }.
 
+%% Attach an exception interface when the log event carries a raw Erlang
+%% stacktrace, either in the logger metadata or in the report itself. The
+%% stacktrace makes Sentry group the event by frames instead of by message.
+%% Crash reports handled by describe/2 build their own exception or threads
+%% and are left untouched.
+maybe_exception(#{exception := _} = Event, _LogEvent) ->
+    Event;
+maybe_exception(#{threads := _} = Event, _LogEvent) ->
+    Event;
+maybe_exception(Event, #{msg := Msg} = LogEvent) ->
+    Meta = maps:get(meta, LogEvent, #{}),
+    Report = msg_report(Msg),
+    case stacktrace_of(Meta, Report) of
+        undefined ->
+            Event;
+        Trace ->
+            Event#{
+                exception => #{
+                    values => [
+                        #{
+                            type => exception_type(Report, Meta, Event),
+                            value => exception_value(Report, Event),
+                            mechanism => #{type => logging, handled => true},
+                            stacktrace => #{
+                                frames => lists:reverse([frame(T) || T <- Trace])
+                            }
+                        }
+                    ]
+                }
+            }
+    end.
+
+msg_report({report, Report}) when is_map(Report) ->
+    Report;
+msg_report({report, Report}) when is_list(Report) ->
+    maps:from_list([{K, V} || {K, V} <- Report, is_atom(K)]);
+msg_report(_Msg) ->
+    #{}.
+
+stacktrace_of(Meta, Report) ->
+    Candidates = [maps:get(stacktrace, Meta, undefined), maps:get(stacktrace, Report, undefined)],
+    case [T || T <- Candidates, is_stacktrace(T)] of
+        [Trace | _] -> Trace;
+        [] -> undefined
+    end.
+
+is_stacktrace([_ | _] = Trace) -> lists:all(fun is_stackframe/1, Trace);
+is_stacktrace(_) -> false.
+
+is_stackframe({M, F, A, Opts}) when is_atom(M), is_atom(F), is_list(Opts) ->
+    is_integer(A) orelse is_list(A);
+is_stackframe(_) ->
+    false.
+
+exception_type(#{exception := Exception}, _Meta, _Event) ->
+    print(Exception);
+exception_type(Report, Meta, Event) ->
+    case exception_class(Meta, Report) of
+        undefined -> exception_value(Report, Event);
+        Class -> print(Class)
+    end.
+
+exception_class(#{class := Class}, _Report) when is_atom(Class) ->
+    Class;
+exception_class(_Meta, #{class := Class}) when is_atom(Class) ->
+    Class;
+exception_class(_Meta, #{exception_class := Class}) when is_atom(Class) ->
+    Class;
+exception_class(_Meta, _Report) ->
+    undefined.
+
+exception_value(Report, _Event) when map_size(Report) > 0 ->
+    Fields = [message, msg, reason],
+    case [maps:get(F, Report) || F <- Fields, is_map_key(F, Report)] of
+        [Message | _] -> format("~tkp", [Message]);
+        [] -> format("~tkp", [Report])
+    end;
+exception_value(_Report, #{logentry := #{formatted := Formatted}}) ->
+    Formatted;
+exception_value(_Report, _Event) ->
+    <<"unknown">>.
+
 maybe_mfa(E0, _Message, _Meta) ->
     E0.
 
@@ -317,10 +400,24 @@ frame({M, F, A, Opts}) ->
         _ when is_integer(A) -> ArgNum = A;
         _ when is_list(A) -> ArgNum = length(A)
     end,
-    F0 = #{function => format("~tp:~tp/~b", [M, F, ArgNum])},
+    F0 = #{
+        function => format("~tp:~tp/~b", [M, F, ArgNum]),
+        in_app => frame_in_app(lists:keyfind(file, 1, Opts))
+    },
     F1 = frame_extra(F0, lists:keyfind(file, 1, Opts)),
     F2 = frame_extra(F1, lists:keyfind(line, 1, Opts)),
     F2.
+
+frame_in_app({file, "/" ++ _ = File}) ->
+    % Rebar3 keeps dependency source trees under `_build`, so absolute paths
+    % that do not contain `_build` are treated as application code. Relative
+    % paths (OTP modules) and frames without file info are not.
+    case string:find(File, "/_build/") of
+        nomatch -> true;
+        _Match -> false
+    end;
+frame_in_app(_File) ->
+    false.
 
 frame_extra(F, {file, String}) ->
     F#{filename => unicode:characters_to_binary(String)};

--- a/test/golare_sentry_SUITE.erl
+++ b/test/golare_sentry_SUITE.erl
@@ -68,6 +68,9 @@ groups() ->
             format_log,
             format_log_mfa,
             report_map,
+            report_map_stacktrace_meta,
+            report_map_stacktrace_in_report,
+            format_log_stacktrace_meta,
             supervisor_crash,
             proc_lib_crash
         ]}
@@ -222,7 +225,10 @@ supervisor_crash(_Config) ->
             tag => error_report, type => supervisor_report, report_cb => fun supervisor:format_log/2
         }
     },
-    LogItem = #{level => error, meta => Meta#{time => 0}, msg => Report},
+    %% A stacktrace in metadata must not override the exception that the
+    %% supervisor report already builds.
+    MetaTrace = [{erlang, apply, 2, []}],
+    LogItem = #{level => error, meta => Meta#{time => 0, stacktrace => MetaTrace}, msg => Report},
     {ok, EventId} = golare_logger_h:log(LogItem, #{}),
     {_, Item} = wait_for(EventId),
     ct:pal(default, "Captured: ~p", [Item]),
@@ -391,6 +397,205 @@ report_map(_Config) ->
                 <<"class">> := _,
                 <<"stacktrace">> := _,
                 <<"reason">> := _
+            }
+        },
+        Item
+    ),
+    ok.
+
+report_map_stacktrace_meta(_Config) ->
+    Trace = [
+        {rest_util_notification_info_content, incoming_share_from_user, 2, [
+            {file, "/build/src/rest/util/rest_util_notification_info_content.erl"}, {line, 158}
+        ]},
+        {rest_util_notification_info_content, build_shared_user, 4, [
+            {file, "/build/src/rest/util/rest_util_notification_info_content.erl"}, {line, 113}
+        ]},
+        {rest_util_notification_info_content, get_notification_info, 1, [
+            {file, "/build/src/rest/util/rest_util_notification_info_content.erl"}, {line, 65}
+        ]},
+        {s2_maybe, lift, 1, [
+            {file, "/build/_build/default/lib/stdlib2/src/s2_maybe.erl"}, {line, 76}
+        ]},
+        {greph, '-eval/3-fun-1-', 4, [
+            {file, "/build/_build/default/lib/greph/src/greph.erl"}, {line, 178}
+        ]},
+        {otel_tracer_default, with_span, 5, [
+            {file, "/build/_build/default/lib/opentelemetry/src/otel_tracer_default.erl"},
+            {line, 47}
+        ]},
+        {lists, foldl_1, 3, [{file, "lists.erl"}, {line, 2471}]}
+    ],
+    Report = #{
+        reason => {"Unknown failure reason", rest_util_notification_info_content},
+        exception => {badmatch, false},
+        resource => rest_util_notification_info_content
+    },
+    Meta = #{time => 0, stacktrace => Trace},
+    LogItem = #{level => warning, meta => Meta, msg => {report, Report}},
+    {ok, EventId} = golare_logger_h:log(LogItem, #{}),
+    {_, Item} = wait_for(EventId),
+    ct:pal(default, "Captured:~n~p", [Item]),
+    ?assertMatch(
+        #{
+            <<"level">> := <<"warning">>,
+            <<"logentry">> := #{
+                <<"formatted">> :=
+                    <<"{\"Unknown failure reason\",rest_util_notification_info_content}">>
+            },
+            <<"exception">> := #{
+                <<"values">> := [
+                    #{
+                        <<"type">> := <<"{badmatch,false}">>,
+                        <<"value">> :=
+                            <<"{\"Unknown failure reason\",rest_util_notification_info_content}">>,
+                        <<"mechanism">> := #{
+                            <<"type">> := <<"logging">>,
+                            <<"handled">> := true
+                        },
+                        <<"stacktrace">> := #{
+                            <<"frames">> := [
+                                #{
+                                    <<"function">> := <<"lists:foldl_1/3">>,
+                                    <<"filename">> := <<"lists.erl">>,
+                                    <<"lineno">> := 2471,
+                                    <<"in_app">> := false
+                                },
+                                #{
+                                    <<"function">> := <<"otel_tracer_default:with_span/5">>,
+                                    <<"lineno">> := 47,
+                                    <<"in_app">> := false
+                                },
+                                #{
+                                    <<"function">> := <<"greph:'-eval/3-fun-1-'/4">>,
+                                    <<"lineno">> := 178,
+                                    <<"in_app">> := false
+                                },
+                                #{
+                                    <<"function">> := <<"s2_maybe:lift/1">>,
+                                    <<"lineno">> := 76,
+                                    <<"in_app">> := false
+                                },
+                                #{
+                                    <<"function">> :=
+                                        <<"rest_util_notification_info_content:get_notification_info/1">>,
+                                    <<"lineno">> := 65,
+                                    <<"in_app">> := true
+                                },
+                                #{
+                                    <<"function">> :=
+                                        <<"rest_util_notification_info_content:build_shared_user/4">>,
+                                    <<"lineno">> := 113,
+                                    <<"in_app">> := true
+                                },
+                                #{
+                                    <<"function">> :=
+                                        <<"rest_util_notification_info_content:incoming_share_from_user/2">>,
+                                    <<"filename">> :=
+                                        <<"/build/src/rest/util/rest_util_notification_info_content.erl">>,
+                                    <<"lineno">> := 158,
+                                    <<"in_app">> := true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        Item
+    ),
+    ok.
+
+report_map_stacktrace_in_report(_Config) ->
+    Trace = [
+        {erlang, hd, [[]], [{error_info, #{module => erl_erts_errors}}]},
+        {payment_consumer, handle_message, 1, [
+            {file, "src/payments/payment_consumer.erl"}, {line, 40}
+        ]},
+        {erlang, apply, 2, []}
+    ],
+    Report = #{
+        msg => <<"consumer crashed">>,
+        % class takes precedence over exception_class when both are present
+        class => error,
+        exception_class => throw,
+        stacktrace => Trace
+    },
+    LogItem = #{level => error, meta => #{time => 0}, msg => {report, Report}},
+    {ok, EventId} = golare_logger_h:log(LogItem, #{}),
+    {_, Item} = wait_for(EventId),
+    ct:pal(default, "Captured:~n~p", [Item]),
+    ?assertMatch(
+        #{
+            <<"level">> := <<"error">>,
+            <<"exception">> := #{
+                <<"values">> := [
+                    #{
+                        <<"type">> := <<"error">>,
+                        <<"value">> := <<"<<\"consumer crashed\">>">>,
+                        <<"stacktrace">> := #{
+                            <<"frames">> := [
+                                #{<<"function">> := <<"erlang:apply/2">>},
+                                #{
+                                    <<"function">> := <<"payment_consumer:handle_message/1">>,
+                                    <<"filename">> := <<"src/payments/payment_consumer.erl">>,
+                                    <<"lineno">> := 40
+                                },
+                                #{<<"function">> := <<"erlang:hd/1">>}
+                            ]
+                        }
+                    }
+                ]
+            },
+            <<"extra">> := #{
+                <<"class">> := _,
+                <<"stacktrace">> := _
+            }
+        },
+        Item
+    ),
+    ok.
+
+format_log_stacktrace_meta(_Config) ->
+    Trace = [
+        {rest_auth_util, authenticate, 2, [
+            {file, "/build/src/rest/rest_auth_util.erl"}, {line, 319}
+        ]},
+        {erlang, apply, 2, []}
+    ],
+    Meta = #{time => 0, class => throw, stacktrace => Trace},
+    LogItem = #{level => error, meta => Meta, msg => {"auth failed for ~s", ["mobile-bankid"]}},
+    {ok, EventId} = golare_logger_h:log(LogItem, #{}),
+    {_, Item} = wait_for(EventId),
+    ct:pal(default, "Captured:~n~p", [Item]),
+    ?assertMatch(
+        #{
+            <<"level">> := <<"error">>,
+            <<"logentry">> := #{
+                <<"formatted">> := <<"auth failed for mobile-bankid">>,
+                <<"message">> := <<"auth failed for ~s">>
+            },
+            <<"exception">> := #{
+                <<"values">> := [
+                    #{
+                        <<"type">> := <<"throw">>,
+                        <<"value">> := <<"auth failed for mobile-bankid">>,
+                        <<"mechanism">> := #{
+                            <<"type">> := <<"logging">>,
+                            <<"handled">> := true
+                        },
+                        <<"stacktrace">> := #{
+                            <<"frames">> := [
+                                #{<<"function">> := <<"erlang:apply/2">>, <<"in_app">> := false},
+                                #{
+                                    <<"function">> := <<"rest_auth_util:authenticate/2">>,
+                                    <<"lineno">> := 319,
+                                    <<"in_app">> := true
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
         },
         Item


### PR DESCRIPTION
## Problem

The logger handler only produced Sentry stacktrace frames for **structured OTP crash reports** (`proc_lib`/`gen_server`/`supervisor`). Application code that catches an exception and logs it — with the stacktrace either in the logger metadata *or* in the report itself — had its stacktrace dropped, so the Sentry event carried only a message and no frames, and Sentry grouped by message.

Two real patterns across our services:
- **`kivra_core`** logs `?warning(Report, #{stacktrace => Stacktrace})` — stacktrace in **metadata**.
- **`cashier`** logs `?LOG_ALERT(#{..., stacktrace => Stacktrace})` (single-arg) — stacktrace in the **report**.

## Fix

`maybe_exception/2` runs in `log/2` after `describe/2`, on **every log type** (report, string, and format logs). When the event carries a raw Erlang stacktrace in metadata or in the report (`stacktrace_of/2`), it attaches a Sentry Exception interface in the canonical `exception.values[]` shape, consistent with the existing supervisor/proc_lib paths. Crash reports that already built their own `exception`/`threads` are left untouched (guarded).

The exception fields:
- **type** — the report's `exception` field when present, else an exception class (`class` in metadata, then `class` or `exception_class` in the report — all in use by callers), else the message.
- **value** — the report's `message`/`msg`/`reason` field, or the formatted message for string/format logs.
- **mechanism** — `{type: logging, handled: true}`, the convention for events created from log records.
- **stacktrace** — the frames, oldest first.

Stacktrace values are validated as lists of `{M, F, ArityOrArgs, Opts}` frames (`is_stacktrace/1`), so non-stacktrace `stacktrace` keys (e.g. pre-formatted or map-shaped values) are left in `extra` as before instead of crashing the handler. BIF frames such as `{erlang, apply, 2, []}` get no `filename`/`lineno`; args-instead-of-arity frames contribute only their length, so argument values never leak.

Frames are also marked **`in_app`**: absolute paths outside the rebar3 `_build` tree are application code; relative paths (OTP) and frames without file info are not. Sentry highlights the offending application frames and folds away dependency/OTP noise. This applies to every frame the handler emits, crash reports included.

## Result

Events that previously grouped by message now regroup by their in-app stacktrace frames, so distinct bug sites become distinct, actionable issues — with a rendered stacktrace, like we had with Raven.

## Tests

`golare_sentry_SUITE` gains `report_map_stacktrace_meta` (kivra_core-shaped, metadata source, real production stacktrace incl. fun frames and dep paths), `report_map_stacktrace_in_report` (cashier-shaped, report source, BIF frames, class precedence), and `format_log_stacktrace_meta` (format log + metadata class). The supervisor crash test now includes a metadata stacktrace to prove crash-report exceptions are not overridden. Full suite green (26 tests).

# Integrations

Soak PR (deploys the branch pin to kivra_core sandbox + production, per review): kivra/kivra_core#6357

Green CI runs for `kivra_core` and `cashier` here:

* https://github.com/kivra/kivra_core/compare/claude/test-golare-stacktrace-fix
* https://github.com/kivra/cashier/compare/claude/test-golare-stacktrace-fix

## Notes

- Supersedes #7 (which handled only the metadata source).
- Orthogonal to #9 (`golare_interface:exception/4` hardening for the events API); the logger path does not use it. Once both merge, a follow-up could unify the two `in_app` implementations.

- Grouping heads-up for `cashier`: `cashier_cowboy_handler:handle_exception/5` reports each crash twice — a rich event via `golare:capture_event/1` and a `?LOG_ERROR` with the stacktrace in the report. Today the logger event is message-only and groups into a separate issue; with this change it carries the same frames and groups into the same issue as the rich event. Fewer duplicate issues, same event volume. If one event per crash is preferred, drop the `stacktrace` field from that log call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
