### PR TITLE
fix(interface): tolerate stacktrace frames without file/line

### DIFF
--- a/src/golare_interface.erl
+++ b/src/golare_interface.erl
@@ -173,13 +173,22 @@ exception_stacktrace_frame({Module, Function, Args, Meta}) ->
             A when is_list(A) -> length(A)
         end,
     File = proplists:get_value(file, Meta),
-    #{
+    Frame0 = #{
         in_app => exception_stacktrace_frame_in_app(File),
         function => iolist_to_binary(io_lib:format("~p/~p", [Function, Arity])),
-        filename => Module,
-        abs_path => iolist_to_binary(File),
-        lineno => proplists:get_value(line, Meta)
-    }.
+        filename => Module
+    },
+    % Raw process stacktraces (e.g. BIF frames like `{erlang, apply, 2, []}`)
+    % may carry no file or line, so only add those keys when present.
+    Frame1 =
+        case File of
+            undefined -> Frame0;
+            _ -> Frame0#{abs_path => iolist_to_binary(File)}
+        end,
+    case proplists:get_value(line, Meta) of
+        undefined -> Frame1;
+        Line -> Frame1#{lineno => Line}
+    end.
 
 exception_stacktrace_frame_in_app("/" ++ _ = File) ->
     % Rebar3 keeps dependency source trees under `_build`, so absolute paths

--- a/test/golare_event_SUITE.erl
+++ b/test/golare_event_SUITE.erl
@@ -18,6 +18,7 @@ all() ->
         exception,
         exception_handled,
         exception_in_app,
+        exception_frame_without_fileinfo,
         message,
         request,
         thread,
@@ -125,6 +126,44 @@ exception_in_app(_Config) ->
         },
         Result
     ),
+    ?assertJSON(Result).
+
+exception_frame_without_fileinfo(_Config) ->
+    %% Raw process stacktraces contain BIF frames with no file/line info, e.g.
+    %% `{erlang, apply, 2, []}`. The frame builder must not crash on these and
+    %% must omit abs_path/lineno rather than emit them as undefined.
+    Result = golare:event(#{}, [
+        golare_interface:exception(error, badarith, [
+            {my_module, my_fun, 1, [{file, "/app/src/my_module.erl"}, {line, 7}]},
+            {erlang, apply, 2, []}
+        ])
+    ]),
+    ?assertMatch(
+        #{
+            exception := [
+                #{
+                    type := error,
+                    value := ~"badarith",
+                    stacktrace := #{
+                        frames := [
+                            #{function := ~"apply/2", filename := erlang, in_app := false},
+                            #{
+                                function := ~"my_fun/1",
+                                filename := my_module,
+                                in_app := true,
+                                abs_path := ~"/app/src/my_module.erl",
+                                lineno := 7
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        Result
+    ),
+    #{exception := [#{stacktrace := #{frames := [BifFrame | _]}}]} = Result,
+    ?assertNot(is_map_key(abs_path, BifFrame)),
+    ?assertNot(is_map_key(lineno, BifFrame)),
     ?assertJSON(Result).
 
 message(_Config) ->


### PR DESCRIPTION
## Problem

`golare_interface:exception/4` builds a frame per stacktrace entry and unconditionally did:

```erlang
abs_path => iolist_to_binary(File),
lineno   => proplists:get_value(line, Meta)
```

Raw process stacktraces routinely contain frames with **no file/line** — e.g. BIF frames like `{erlang, apply, 2, []}`. For those, `File` is `undefined` and `iolist_to_binary(undefined)` raises `badarg`, so the whole `exception/4` call crashes. Any user of the events API (`golare:event/2` + the exception interface) that passes a real caught stacktrace can hit this.

## Fix

Emit `abs_path`/`lineno` only when the frame actually carries them; otherwise omit the keys. `in_app`, `function`, and `filename` are unchanged.

## Scope

This only affects the **events API**. The logger handler builds its own frames and is unaffected, so this is independent of #8.

## Tests

New `golare_event_SUITE` case `exception_frame_without_fileinfo` exercises a fileless BIF frame alongside a normal app frame and asserts the fileless frame carries neither `abs_path` nor `lineno` and JSON-encodes cleanly. Full event suite green (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)